### PR TITLE
Resolvendo questao dos dashboard do grafana que nao iniciava

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help create-env install clean devstack run run-dev run-worker test test-all lint format
+.PHONY: help create-env install clean devstack run run-dev run-worker init-grafana test test-all lint format
 
 # Colors
 BLUE := \033[36m
@@ -157,6 +157,23 @@ run: build ## Run complete stack (devstack + API + Celery)
 	@echo "$(BLUE)   Grafana:$(RESET)         http://localhost:3000/ (admin/admin)"
 	@echo "$(BLUE)   Prometheus:$(RESET)      http://localhost:9090/"
 	@echo ""
+	@echo "$(YELLOW)💡 Tip: Run 'make init-grafana' to populate dashboards with sample data$(RESET)"
+	@echo ""
+
+init-grafana: ## Initialize Grafana dashboards with sample data
+	@echo "$(BLUE)Initializing Grafana with sample data...$(RESET)"
+	@echo "$(YELLOW)⏳ Checking if services are running...$(RESET)"
+	@if ! curl -s http://localhost:8000/health/ >/dev/null 2>&1; then \
+		echo "$(RED)❌ API is not running. Please run 'make run' first.$(RESET)"; \
+		echo "$(YELLOW)Services needed: API (8000), Grafana (3000), Prometheus (9090)$(RESET)"; \
+		exit 1; \
+	fi
+	@if ! curl -s http://localhost:3000/api/health >/dev/null 2>&1; then \
+		echo "$(RED)❌ Grafana is not running. Please run 'make run' first.$(RESET)"; \
+		exit 1; \
+	fi
+	@echo "$(GREEN)✅ Services are running. Proceeding with initialization...$(RESET)"
+	@./scripts/init-grafana.sh
 
 test: ## Run pytest tests
 	@echo "$(BLUE)Running pytest tests...$(RESET)"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -154,6 +154,10 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/weather-service.json
+      - GF_LIVE_ALLOWED_ORIGINS=*
+      - GF_FEATURE_TOGGLES_ENABLE=live
+      - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=1s
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning

--- a/docker/grafana/dashboards/weather-service.json
+++ b/docker/grafana/dashboards/weather-service.json
@@ -20,7 +20,6 @@
   "graphTooltip": 0,
   "id": null,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "datasource": {
@@ -30,7 +29,37 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "barWidth": 0.97,
+            "barRadius": 0.1
           },
           "mappings": [],
           "thresholds": {
@@ -48,7 +77,20 @@
           },
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.axisLabel",
+                "value": "small"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -58,30 +100,27 @@
       },
       "id": 1,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
         },
-        "textMode": "auto"
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
       "pluginVersion": "8.5.0",
       "targets": [
         {
-          "expr": "sum(django_http_requests_before_middlewares_total)",
+          "expr": "sum(rate(django_http_requests_before_middlewares_total{path!=\"/health/\"}[10m])) * 600",
           "interval": "",
-          "legendFormat": "Total HTTP Requests",
+          "legendFormat": "Requests/10min",
           "refId": "A"
         }
       ],
-      "title": "Total HTTP Requests",
-      "type": "stat"
+      "title": "Media requests a cada 10 minutos",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -358,8 +397,8 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -420,13 +459,13 @@
       },
       "targets": [
         {
-          "expr": "weather_service_requests_total",
+          "expr": "sum(increase(weather_service_requests_total[5m])) by (city, cached)",
           "interval": "",
-          "legendFormat": "{{city}} (cached: {{cached}})",
+          "legendFormat": "{{city}} (cached: {{cached}}) - 5min",
           "refId": "A"
         }
       ],
-      "title": "Weather Service Requests by City",
+      "title": "Weather Service Requests by City (5min intervals)",
       "type": "timeseries"
     },
     {
@@ -868,6 +907,7 @@
     }
   ],
   "refresh": "5s",
+  "liveNow": true,
   "schemaVersion": 36,
   "style": "dark",
   "tags": [
@@ -879,7 +919,7 @@
     "list": []
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},

--- a/scripts/init-grafana.sh
+++ b/scripts/init-grafana.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Script para inicializar o Grafana com dados e garantir que as queries sejam executadas
+
+echo "🚀 Initializing Grafana with sample data..."
+
+# Wait for services to be ready
+echo "⏳ Waiting for services to be ready..."
+sleep 10
+
+# Make some sample requests to generate data
+echo "📊 Generating sample data..."
+
+# Sample weather requests to different cities
+cities=("São Paulo" "Rio de Janeiro" "Belo Horizonte" "Salvador" "Fortaleza")
+
+for city in "${cities[@]}"; do
+    echo "🌤️  Making request for $city..."
+    curl -s "http://localhost:8000/api/v1/weather/?city=$city" > /dev/null || true
+    sleep 1
+done
+
+# Make some cached requests
+echo "🔄 Making cached requests..."
+for city in "${cities[@]}"; do
+    echo "💾 Making cached request for $city..."
+    curl -s "http://localhost:8000/api/v1/weather/?city=$city" > /dev/null || true
+    sleep 0.5
+done
+
+# Make requests to trigger rate limiting
+echo "⚡ Testing rate limiting..."
+for i in {1..10}; do
+    curl -s "http://localhost:8000/api/v1/weather/?city=São Paulo" > /dev/null || true
+    sleep 0.1
+done
+
+echo "✅ Sample data generated successfully!"
+echo "🎯 Grafana should now have data to display in dashboards"
+echo "🌐 Access Grafana at: http://localhost:3000"
+echo "👤 Login: admin / admin"


### PR DESCRIPTION
## Summary by Sourcery

Enable initialization of Grafana dashboards with sample data by adding a dedicated make target, helper script, and Docker Compose configuration for dashboard provisioning and live settings.

New Features:
- Add init-grafana make target
- Introduce init-grafana.sh script to generate sample data and perform health checks

Enhancements:
- Display tip in make run output to remind users to run init-grafana
- Configure Grafana service in Docker Compose with default dashboard path, allowed origins, live feature toggles, and minimum refresh interval